### PR TITLE
Fixed typo Error on Polkadot validator

### DIFF
--- a/src/dot_validator.js
+++ b/src/dot_validator.js
@@ -40,7 +40,7 @@ module.exports = {
             const addressFormat = addressFormats.find(af => af.addressLength === addressAndChecksum.length);
 
             if (!addressFormat) {
-                throw new Erorr('Invalid address length');
+                throw new Error('Invalid address length');
             }
 
             const decodedAddress = cryptoUtils.byteArray2hexStr(addressAndChecksum.slice(0, addressFormat.accountIndexLength));


### PR DESCRIPTION
Fixing the `throw new Error` typo on the new polkadot validator.