### PR TITLE
Fix AVAX, include AVAXC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 .idea
 .DS_Store
+*.swp

--- a/src/avax_validator.js
+++ b/src/avax_validator.js
@@ -1,0 +1,12 @@
+var bip173 = require('./bip173_validator.js')
+
+// Checks validity in Avalanche X- & P- chains
+module.exports = {
+  isValidAddress: function (address, currency, opts = {}) {
+    // AVAX addresses can have an ID at the beginning
+    let [id, addr] = address.split('-')
+    if (!addr) addr = id
+
+    return bip173.isValidAddress(addr, currency, opts)
+  }
+}

--- a/src/avaxc_validator.js
+++ b/src/avaxc_validator.js
@@ -1,0 +1,11 @@
+var ethereum = require('./ethereum_validator')
+
+// Validate C-Chain addresses (AVAXC)
+module.exports = {
+  isValidAddress: function (address) {
+    // While rarely used, C-Chain addresses can include a chain ID
+    let [id, addr] = address.split('-')
+    if (!addr) addr = id
+    return ethereum.isValidAddress(addr)
+  }
+}

--- a/src/currencies.js
+++ b/src/currencies.js
@@ -18,6 +18,7 @@ var DotValidator = require('./dot_validator');
 var BIP173Validator = require('./bip173_validator')
 var Base58Validator = require('./base58_validator')
 var AVAXValidator = require('./avax_validator')
+var AVAXCValidator = require('./avaxc_validator')
 
 // defines P2PKH and P2SH address types for standard (prod) and testnet networks
 var CURRENCIES = [{
@@ -600,6 +601,11 @@ var CURRENCIES = [{
         symbol: 'avax',
         bech32Hrp: { prod: ['avax'], testnet: ['cascade', 'denali', 'everest', 'fuji', 'local', 'custom'] },
         validator: AVAXValidator
+    },
+    {
+        name: 'Avalanche C-Chain',
+        symbol: 'avaxc',
+        validator: AVAXCValidator
     },
 ];
 

--- a/src/currencies.js
+++ b/src/currencies.js
@@ -17,6 +17,7 @@ var AlgoValidator = require('./algo_validator');
 var DotValidator = require('./dot_validator');
 var BIP173Validator = require('./bip173_validator')
 var Base58Validator = require('./base58_validator')
+var AVAXValidator = require('./avax_validator')
 
 // defines P2PKH and P2SH address types for standard (prod) and testnet networks
 var CURRENCIES = [{
@@ -597,7 +598,8 @@ var CURRENCIES = [{
     {
         name: 'Avalanche',
         symbol: 'avax',
-        validator: ETHValidator,
+        bech32Hrp: { prod: ['avax'], testnet: ['cascade', 'denali', 'everest', 'fuji', 'local', 'custom'] },
+        validator: AVAXValidator
     },
 ];
 

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -828,6 +828,17 @@ describe('WAValidator.validate()', function () {
             valid('G4qGCGF4vWGPzYi2pxc2Djvgv3j8NiWaHQMgTVebCX6W', 'sol');
         });
 
+        it('should return true for correct X- & P- Avalanche chain addreses', function () {
+            valid('P-avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avax');
+            valid('X-avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avax');
+            valid('avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avax');
+            valid('P-avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avalanche');
+            valid('X-avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avalanche');
+            valid('avax1ks5kfds2mk8hxwdfdg6dya2v3pggdwf6enj9lt', 'avalanche');
+
+            valid('X-fuji1xpmx0ljrpvqexrvrj26fnggvr0ax9wm32gaxmx', 'avalanche', 'testnet');
+            valid('fuji1xpmx0ljrpvqexrvrj26fnggvr0ax9wm32gaxmx', 'avalanche', 'testnet');
+        });
     });
 
     describe('invalid results', function () {

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -839,6 +839,13 @@ describe('WAValidator.validate()', function () {
             valid('X-fuji1xpmx0ljrpvqexrvrj26fnggvr0ax9wm32gaxmx', 'avalanche', 'testnet');
             valid('fuji1xpmx0ljrpvqexrvrj26fnggvr0ax9wm32gaxmx', 'avalanche', 'testnet');
         });
+
+        it('should return true for correct Avalanche C-chain address (AVAXC)', function () {
+            valid('C-0x572f4D80f10f663B5049F789546f25f70Bb62a7F', 'avaxc');
+            valid('0x572f4D80f10f663B5049F789546f25f70Bb62a7F', 'avaxc');
+            valid('C-0x572f4D80f10f663B5049F789546f25f70Bb62a7F', 'avalanche c-chain');
+            valid('0x572f4D80f10f663B5049F789546f25f70Bb62a7F', 'avalanche c-chain');
+        });
     });
 
     describe('invalid results', function () {


### PR DESCRIPTION
The current AVAX implementation is actually for the C-Chain, which is actually AVAXC according to [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).

**These changes are breaking**  but accomplish two things:
* Fix the AVAX implementation to parse X- & P- chains instead of the C-Chain
* Add in AVAXC support to continue parsing the C-Chain

A couple questions I have:
* Would you like the `dist/` folder committed as well?
* Would you prefer the ID stripping to be its own function? My thinking was that it was unnecessary abstraction to make it a function

References:
* [Avalanche docs - What is an address](https://support.avax.network/en/articles/4596397-what-is-an-address)
* [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)