### PR TITLE
Require Buffer in Blake256 for web browser

### DIFF
--- a/src/crypto/blake256.js
+++ b/src/crypto/blake256.js
@@ -1,4 +1,7 @@
 'use strict';
+if (!global.Buffer) {
+  global.Buffer = require('buffer').Buffer;
+}
 
 /**
  * Credits to https://github.com/cryptocoinjs/blake-hash


### PR DESCRIPTION
The previous fix still encounters an error with Buffer not being defined in the browser, likely due to the import/execution order of the build files. 