### PR TITLE
Fix BSC address validator

### DIFF
--- a/src/currencies.js
+++ b/src/currencies.js
@@ -603,7 +603,7 @@ var CURRENCIES = [{
     },
     {
         name: 'BinanceSmartChain',
-        symbol: 'bnb',
+        symbol: 'bsc',
         validator: ETHValidator,
     },
     {


### PR DESCRIPTION
Currently BSC is saved as BNB, which is incorrect. The name of the network is BSC not BNB. 