### PR TITLE
Fix Cardano (ADA) testnet support.

### DIFF
--- a/src/currencies.js
+++ b/src/currencies.js
@@ -265,7 +265,7 @@ var CURRENCIES = [{
     }, {
         name: 'Cardano',
         symbol: 'ada',
-        bech32Hrp: { prod: ['addr'], testnet: ['addr']},
+        bech32Hrp: { prod: ['addr'], testnet: ['addr_test']},
         validator: ADAValidator
     }, {
         name: 'Monero',

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -549,7 +549,8 @@ describe('WAValidator.validate()', function () {
             valid('4swhHtxKapQbj3TZEipgtp7NQzcRWDYqCxXYoPQWjGyHmhxS1w1TjUEszCQT1sQucGwmPQMYdv1FYs3d51KgoubviPBf', 'cardano');
 
             valid('addr1qxy3w62dupy9pzmpdfzxz4k240w5vawyagl5m9djqquyymrtm3grn7gpnjh7rwh2dy62hk8639lt6kzn32yxq960usnq9pexvt', 'cardano');
-            valid('addr1skemppwfevyk0lshu2w8j34707s3t3t58a04xcx5ccevrcmvpmxg2qt4pk0', 'cardano', 'testnet');
+            valid('addr_test1vppht3ffmu4rerk4r50h6447stfhkm86ttc64ghza7wx8mg225lw4', 'cardano', 'testnet');
+            valid('addr_test1vpymmxpazg6n5jxnntg4yy3zp67hrhfl39lt9x4cnu7ttrsh9ldm4', 'cardano', 'testnet');
         });
 
         it('should return true for correct monero addresses', function () {


### PR DESCRIPTION
Cardano testnet (both pre-prod and preview) addresses use "addr_test" as the HRP (human readable portion) of the Bech32 address to distinguish them from mainnet addresses.

I've updated the tests but I'm just not familiar with working with Node or how to test this appropriately.